### PR TITLE
use relative path in Android.mk

### DIFF
--- a/app/src/main/jni/dvmnative/Android.mk
+++ b/app/src/main/jni/dvmnative/Android.mk
@@ -21,7 +21,7 @@ include $(CLEAR_VARS)
 LOCAL_CPP_EXTENSION := .cxx .cpp .cc
 
 LOCAL_MODULE    := elfinfo
-LOCAL_SRC_FILES := C:\Users\jxht\AndroidStudioProjects\ZjDroid\app\src\main\jni\dvmnative\elfinfo.cpp
+LOCAL_SRC_FILES := $(LOCAL_PATH)/elfinfo.cpp
 LOCAL_LDLIBS    := -ldl -llog
 
 include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
源码使用相对路径，解决编译错误。